### PR TITLE
 Fix SQL formatting for PostgreSQL jsonb column operators

### DIFF
--- a/lib/whoop.rb
+++ b/lib/whoop.rb
@@ -12,6 +12,9 @@ require_relative "whoop/formatters/sql_formatter"
 #   config.level = :debug
 # end
 
+class FormatNotSupportedError < StandardError
+end
+
 module Whoop
   mattr_accessor :logger
   @@logger = ActiveSupport::Logger.new($stdout)
@@ -53,6 +56,8 @@ module Whoop
       explain: false,
       context: nil
     )
+      raise FormatNotSupportedError unless %i[plain json sql].include?(format)
+
       logger_method = detect_logger_method
       color_method = detect_color_method(color)
       formatter_method = detect_formatter_method(format, colorize: color.present?, explain: explain)

--- a/lib/whoop.rb
+++ b/lib/whoop.rb
@@ -56,7 +56,7 @@ module Whoop
       explain: false,
       context: nil
     )
-      raise FormatNotSupportedError unless %i[plain json sql].include?(format)
+      raise FormatNotSupportedError unless FORMATS.include?(format)
 
       logger_method = detect_logger_method
       color_method = detect_color_method(color)

--- a/lib/whoop/formatters/sql_formatter.rb
+++ b/lib/whoop/formatters/sql_formatter.rb
@@ -6,7 +6,13 @@ require "active_record"
 module Whoop
   module Formatters
     module SqlFormatter
-      TOKENS_TO_PRESERVE = ['::', '->>', '->' , '#>>', '#>']
+      PATTERNS_TO_PRESERVE = {
+        '::': ' : : ',
+        '->>': '- > >',
+        '->': '- >',
+        '#>>': '# > >',
+        '#>': '# >'
+      }
 
       # Format the SQL query
       # @param [String] sql The SQL query
@@ -48,11 +54,10 @@ module Whoop
         # Anbt injects additional spaces into joined symbols.
         # This removes them by generating the "broken" collection
         # of symbols, and replacing them with the original.
-        TOKENS_TO_PRESERVE.each do |token|
-          token_with_whitespace = inject_whitespace_into(token)
-          next unless formatted_string.include?(token_with_whitespace)
+        PATTERNS_TO_PRESERVE.each do |token, pattern|
+          next unless formatted_string.include?(pattern)
 
-          formatted_string.gsub!(token_with_whitespace, token)
+          formatted_string.gsub!(pattern, token.to_s)
         end
 
         formatted_string
@@ -72,19 +77,6 @@ module Whoop
         pretty_explain << "\n(#{nrows} #{rows_label})"
 
         pretty_explain.join("\n")
-      end
-
-      # Adds whitespace to tokens so they match the incorrect format
-      # @params [String] token The token to inject whitespace into, ie "->>"
-      # @return [String] The token with additional whitespace, ie "- > >"
-      def self.inject_whitespace_into(token)
-        # Inject whitespace to match the (broken) format
-        token_with_whitespace = token.chars.join(" ")
-
-        # :: is a special case where it needs to strip surrounding whitespace too
-        return token_with_whitespace unless token == '::'
-
-        " #{token_with_whitespace} "
       end
     end
   end

--- a/lib/whoop/formatters/sql_formatter.rb
+++ b/lib/whoop/formatters/sql_formatter.rb
@@ -6,6 +6,9 @@ require "active_record"
 module Whoop
   module Formatters
     module SqlFormatter
+      # Hash of patterns to preserve in the SQL. The key is the expected pattern,
+      # the value is the pattern after it has been "broken" by anbt formatting.
+      # Instances of the value are replaced by the key.
       PATTERNS_TO_PRESERVE = {
         '::': ' : : ',
         '->>': '- > >',

--- a/lib/whoop/formatters/sql_formatter.rb
+++ b/lib/whoop/formatters/sql_formatter.rb
@@ -9,12 +9,13 @@ module Whoop
       # Hash of patterns to preserve in the SQL. The key is the expected pattern,
       # the value is the pattern after it has been "broken" by anbt formatting.
       # Instances of the value are replaced by the key.
+      # Patterns are jsonb column operators from https://www.postgresql.org/docs/15/functions-json.html
       PATTERNS_TO_PRESERVE = {
-        '::': ' : : ',
-        '->>': '- > >',
-        '->': '- >',
-        '#>>': '# > >',
-        '#>': '# >'
+        '::' => ' : : ',
+        '->>' => '- > >',
+        '->' => '- >',
+        '#>>' => '# > >',
+        '#>' => '# >'
       }
 
       # Format the SQL query
@@ -57,10 +58,10 @@ module Whoop
         # Anbt injects additional spaces into joined symbols.
         # This removes them by generating the "broken" collection
         # of symbols, and replacing them with the original.
-        PATTERNS_TO_PRESERVE.each do |token, pattern|
-          next unless formatted_string.include?(pattern)
+        PATTERNS_TO_PRESERVE.each do |correct_pattern, incorrect_pattern|
+          next unless formatted_string.include?(incorrect_pattern)
 
-          formatted_string.gsub!(pattern, token.to_s)
+          formatted_string.gsub!(incorrect_pattern, correct_pattern)
         end
 
         formatted_string

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -103,8 +103,15 @@ RSpec.describe Whoop do
       it 'appropriately formats jsonb column operators' do
         io = setup_whoop
 
-        ['->>', '->' , '#>>', '#>'].each do |token|
-          whoop(token, format: :sql)
+        [
+          %Q['{"a": {"b":"foo"}}'::json -> 'a'],
+          %Q['[1,2,3]'::json ->> 2],
+          %Q['{"a":1,"b":2}'::json ->> 'b'],
+          %Q['{"a": {"b":{"c": "foo"}}}'::json #> '{a,b}'],
+          %Q['{"a":[1,2,3],"b":[4,5,6]}'::json #>> '{a,2}']
+          # ... all examples from https://www.postgresql.org/docs/9.5/functions-json.html
+        ].each do |token|
+          whoop(token, format: :sql, color: false)
           logged_message = io.string
 
           expect(logged_message.uncolorize).to include(token)

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -34,12 +34,15 @@ RSpec.describe Whoop do
     end
 
     context "when the format is invalid" do
-      it "throws a FormatNotSupportedError exception" do
+      it "adds a note listing available formats" do
         io = setup_whoop
+        whoop("Bad format", format: :invalid, color: false)
+        logged_message = io.string
 
-        expect do
-          whoop("Bad format", format: :invalid)
-        end.to raise_error(FormatNotSupportedError)
+        puts logged_message
+
+        expect(logged_message).to include('Bad format')
+        expect(logged_message).to include('Unsupported format used. Available formats: plain, json, and sql')
       end
     end
 
@@ -52,6 +55,7 @@ RSpec.describe Whoop do
         puts logged_message
 
         expect(logged_message).to include('"hello": "world"')
+        expect(logged_message).not_to include('Unsupported format used.')
       end
     end
 
@@ -65,6 +69,7 @@ RSpec.describe Whoop do
         puts logged_message
 
         expect(logged_message).to include("SELECT")
+        expect(logged_message).not_to include('Unsupported format used.')
       end
     end
 

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -99,20 +99,15 @@ RSpec.describe Whoop do
       end
     end
 
-    context 'when parsing PostgreSQL jsonb column operators' do
-      it 'appropriately formats the SQL' do
+    context 'parsing PostgreSQL operators' do
+      it 'appropriately formats jsonb column operators' do
         io = setup_whoop
-        column_operator_examples = [
-          "'[{\"a\":\"foo\"},{\"b\":\"bar\"},{\"c\":\"baz\"}]'::json -> 2",
-        ]
 
-        column_operator_examples.each do |sql|
-          whoop(sql, format: :sql)
+        ['->>', '->' , '#>>', '#>'].each do |token|
+          whoop(token, format: :sql)
           logged_message = io.string
 
-          puts logged_message
-
-          expect(logged_message).to include(sql)
+          expect(logged_message.uncolorize).to include(token)
         end
       end
     end

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Whoop do
       end
     end
 
+    context "when the format is invalid" do
+      it "throws a FormatNotSupportedError exception" do
+        io = setup_whoop
+
+        expect do
+          whoop("Bad format", format: :invalid)
+        end.to raise_error(FormatNotSupportedError)
+      end
+    end
+
     context "when the format is :json" do
       it "writes to the logger" do
         io = setup_whoop

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -108,13 +108,22 @@ RSpec.describe Whoop do
       it 'appropriately formats jsonb column operators' do
         io = setup_whoop
 
+        # Examples from https://www.postgresql.org/docs/9.5/functions-json.html
         [
-          %Q['{"a": {"b":"foo"}}'::json -> 'a'],
-          %Q['[1,2,3]'::json ->> 2],
-          %Q['{"a":1,"b":2}'::json ->> 'b'],
-          %Q['{"a": {"b":{"c": "foo"}}}'::json #> '{a,b}'],
-          %Q['{"a":[1,2,3],"b":[4,5,6]}'::json #>> '{a,2}']
-          # ... all examples from https://www.postgresql.org/docs/9.5/functions-json.html
+          %Q['{"a": {"b":"foo"}}'::json->'a'],
+          %Q['[1,2,3]'::json->>2],
+          %Q['{"a":1,"b":2}'::json->>'b'],
+          %Q['{"a": {"b":{"c": "foo"}}}'::json#>'{a,b}'],
+          %Q['{"a":[1,2,3],"b":[4,5,6]}'::json#>>'{a,2}'],
+          %Q['{"a":1, "b":2}'::jsonb @> '{"b":2}'::jsonb],
+          %Q['{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb],
+          %Q['{"a":1, "b":2}'::jsonb ? 'b'],
+          %Q['{"a":1, "b":2, "c":3}'::jsonb ?| array['b']],
+          %Q['["a", "b"]'::jsonb ?& array['a']],
+          %Q['["a", "b"]'::jsonb || '["c"]'::jsonb],
+          %Q['{"a": "b"}'::jsonb - 'a'],
+          %Q['["a", "b"]'::jsonb - 1],
+          %Q['["a", {"b":1}]'::jsonb #- '{1,b}']
         ].each do |token|
           whoop(token, format: :sql, color: false)
           logged_message = io.string

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe Whoop do
         expect(logged_message).not_to include(context)
       end
     end
+
+    context 'when parsing PostgreSQL jsonb column operators' do
+      it 'appropriately formats the SQL' do
+        io = setup_whoop
+        column_operator_examples = [
+          "'[{\"a\":\"foo\"},{\"b\":\"bar\"},{\"c\":\"baz\"}]'::json -> 2",
+        ]
+
+        column_operator_examples.each do |sql|
+          whoop(sql, format: :sql)
+          logged_message = io.string
+
+          puts logged_message
+
+          expect(logged_message).to include(sql)
+        end
+      end
+    end
   end
 
   private


### PR DESCRIPTION
- Once SQL is formatted by Anbt, replaces broken characters with their fixed ones (ie, "- > >" with "->>")
  - This is not ideal :( I would rather configure Anbt to format the initial string without breaking this, but the config option does not seem to exist
  - They seem to be applied in [::Formatter](https://github.com/sonota88/anbt-sql-formatter/blob/master/lib/anbt-sql-formatter/formatter.rb#L228) but still don't seem to help this specific case.
  
- Stricter choice of formats; if given format is not supported, raise an error.

![image](https://user-images.githubusercontent.com/45462299/229356130-f2d57111-476f-407b-af88-695fbefd3e4c.png)

Questions:
- [x] Is there some hidden anbt config that would be suitable for fixing this instead?
- [x] In tests, I've had to use incredibly short test strings because the output gets colourized by bash & breaks the tests. IE, when testing "::" it returns as:

```
\n\n┏--------------------------------------------------------------------------------\n┆ timestamp: ...n\e[0;39;49m┗--------------------------------------------------------------------------------\n\n\n
```

even with `uncolourize`. What can I do to strip these characters & write better tests?

Closes https://github.com/coderberry/whoop/issues/5