### PR TITLE
Add support for the :pretty formatter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     whoop (1.1.0)
       activerecord (>= 6.1.4)
       activesupport (>= 6.1.4)
+      amazing_print
       anbt-sql-formatter
       colorize
       rouge
@@ -21,6 +22,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    amazing_print (1.5.0)
     anbt-sql-formatter (0.1.0)
     ast (2.4.2)
     bump (0.10.0)
@@ -114,6 +116,7 @@ GEM
     yard (0.9.34)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/generators/whoop/install_generator.rb
+++ b/lib/generators/whoop/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Whoop
   class InstallGenerator < Rails::Generators::Base
     desc "This generator creates an initializer file for the Whoop gem at config/initializers/whoop.rb, with default settings."

--- a/lib/whoop.rb
+++ b/lib/whoop.rb
@@ -5,6 +5,7 @@ require "colorize"
 require "rouge"
 require_relative "whoop/version"
 require_relative "whoop/formatters/json_formatter"
+require_relative "whoop/formatters/pretty_formatter"
 require_relative "whoop/formatters/sql_formatter"
 
 # Whoop.setup do |config|
@@ -27,7 +28,7 @@ module Whoop
 
   module Main
     COLORS = %i[black red green yellow blue magenta cyan white light_black light_red light_green light_yellow light_blue light_magenta light_cyan light_white default].freeze
-    FORMATS = %i[plain json sql].freeze
+    FORMATS = %i[plain pretty json sql].freeze
     PATTERN = "-"
     COUNT = 80
     INDENT = "┆"
@@ -39,7 +40,7 @@ module Whoop
     # @param [String] pattern - the pattern to use for the line (e.g. '-')
     # @param [Integer] count - the number of times to repeat the pattern per line (e.g. 80)
     # @param [Symbol] color - the color to use for the line (e.g. :red)
-    # @param [Symbol] format - the format to use for the message (one of :json, :sql, :plain)
+    # @param [Symbol] format - the format to use for the message (one of :json, :sql, :plain, :pretty (default))
     # @param [Integer] caller_depth - the depth of the caller to use for the source (default: 0)
     # @param [Boolean] explain - whether to explain the SQL query (default: false)
     # @param [Hash] context - Any additional context you'd like to include in the log
@@ -48,7 +49,7 @@ module Whoop
       pattern: PATTERN,
       count: COUNT,
       color: :default,
-      format: :plain,
+      format: :pretty,
       caller_depth: 0,
       explain: false,
       context: nil
@@ -147,6 +148,8 @@ module Whoop
         ->(message) { Whoop::Formatters::JsonFormatter.format(message, colorize: colorize) }
       when :sql
         ->(message) { Whoop::Formatters::SqlFormatter.format(message, colorize: colorize, explain: explain) }
+      when :pretty
+        ->(message) { Whoop::Formatters::PrettyFormatter.format(message) }
       else
         ->(message) { message }
       end

--- a/lib/whoop/formatters/pretty_formatter.rb
+++ b/lib/whoop/formatters/pretty_formatter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "amazing_print"
+
+module Whoop
+  module Formatters
+    module PrettyFormatter
+      # Format the message using AwesomePrint
+      # @param [String] message The object/class/message
+      # @return [String] The formatted message
+      def self.format(message)
+        message.ai
+      end
+    end
+  end
+end

--- a/sig/whoop.rbs
+++ b/sig/whoop.rbs
@@ -29,7 +29,7 @@ module Whoop
     # 
     # _@param_ `color` — - the color to use for the line (e.g. :red)
     # 
-    # _@param_ `format` — - the format to use for the message (one of :json, :sql, :plain)
+    # _@param_ `format` — - the format to use for the message (one of :json, :sql, :plain, :pretty (default))
     # 
     # _@param_ `caller_depth` — - the depth of the caller to use for the source (default: 0)
     # 
@@ -129,5 +129,19 @@ module Whoop
       # _@return_ — The formatted SQL query
       def self.format: (String message, ?colorize: bool) -> String
     end
+
+    module PrettyFormatter
+      # Format the message using AwesomePrint
+      # 
+      # _@param_ `message` — The object/class/message
+      # 
+      # _@return_ — The formatted message
+      def self.format: (String message) -> String
+    end
+  end
+
+  class InstallGenerator < Rails::Generators::Base
+    # sord omit - no YARD return type given, using untyped
+    def install: () -> untyped
   end
 end

--- a/spec/whoop_spec.rb
+++ b/spec/whoop_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Whoop do
         puts logged_message
 
         expect(logged_message).to include("Bad format")
-        expect(logged_message).to include("Unsupported format used. Available formats: plain, json, and sql")
+        expect(logged_message).to include("Unsupported format used. Available formats: plain, pretty, json, and sql")
       end
     end
 
@@ -56,6 +56,20 @@ RSpec.describe Whoop do
 
         expect(logged_message).to include('"hello": "world"')
         expect(logged_message).not_to include("Unsupported format used.")
+      end
+    end
+
+    context "when the format is :pretty" do
+      it "writes to the logger" do
+        io = setup_whoop
+        obj = OpenStruct.new(name: "Eric", location: "Utah")
+        whoop(obj, format: :pretty)
+        logged_message = io.string
+
+        puts logged_message
+
+        expect(logged_message).to include("OpenStruct {")
+        expect(logged_message).to include('"Utah"')
       end
     end
 

--- a/whoop.gemspec
+++ b/whoop.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "anbt-sql-formatter"
   spec.add_dependency "colorize"
   spec.add_dependency "rouge"
+  spec.add_dependency "amazing_print"
 
   spec.add_development_dependency "magic_frozen_string_literal"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Example:

```ruby
obj = OpenStruct.new(name: "Eric", location: "Utah")
whoop(obj, format: :pretty)
```

will generate the whoop output:

```
┏--------------------------------------------------------------------------------
┆ timestamp: 2023-07-10 13:29:50 -0600
┆ source: /Users/eberry/Code/OpenSource/whoop/spec/whoop_spec.rb:66:in `block (4 levels) in <top (required)>'

OpenStruct {
        :name => "Eric",
    :location => "Utah"
}

┗--------------------------------------------------------------------------------
```